### PR TITLE
Add support for STARTTLS

### DIFF
--- a/lib/notifiers.ts
+++ b/lib/notifiers.ts
@@ -1,4 +1,4 @@
-import { SmtpClient } from "./smtp.ts";
+import { ConnectConfigWithAuthentication, SmtpClient } from "./smtp.ts";
 import { getLogger } from "@std/log";
 import { DockerApiContainerEvent } from "./docker-api.ts";
 import { CheckedConfiguration, ConfigOption } from "./env.ts";
@@ -107,8 +107,10 @@ export class SmtpNotifier extends Notifier {
             port: SmtpNotifier.config.port,
             username: SmtpNotifier.config.username,
             password: SmtpNotifier.config.password,
-        };
-        if (SmtpNotifier.config.use_tls) {
+        } as ConnectConfigWithAuthentication;
+        if (!SmtpNotifier.config.use_tls && connection_config.username !== undefined) {
+            await client.connect_starttls(connection_config);
+        } else if (SmtpNotifier.config.use_tls) {
             await client.connect_tls(connection_config);
         } else {
             await client.connect_plain(connection_config);

--- a/lib/smtp.ts
+++ b/lib/smtp.ts
@@ -94,7 +94,7 @@ export class SmtpClient {
         }
 
         if (this.use_authentication(config)) {
-            if (!this.isTlsConn(this.connection)) {
+            if (!this.is_tls_conn(this.connection)) {
                 if (!supports_starttls) {
                     throw new Error("STARTTLS is not supported by the server");
                 }
@@ -119,7 +119,7 @@ export class SmtpClient {
         }
     }
 
-    isTlsConn(arg: Deno.Conn): arg is Deno.TlsConn {
+    is_tls_conn(arg: Deno.Conn): arg is Deno.TlsConn {
         return (arg as Deno.TlsConn).handshake !== undefined;
     }
 

--- a/lib/smtp.ts
+++ b/lib/smtp.ts
@@ -24,7 +24,7 @@ type ConnectConfig = {
     port?: number;
 };
 
-type ConnectConfigWithAuthentication = ConnectConfig & {
+export type ConnectConfigWithAuthentication = ConnectConfig & {
     username: string;
     password: string;
 };
@@ -64,6 +64,14 @@ export class SmtpClient {
         await this.connect(connection, config);
     }
 
+    async connect_starttls(config: ConnectConfigWithAuthentication) {
+        const connection = await Deno.connect({
+            hostname: config.hostname,
+            port: config.port || 587,
+        });
+        await this.connect(connection, config);
+    }
+
     private async connect(connection: Deno.Conn, config: ConnectConfig) {
         this.connection = connection;
         this.reader = this.connection.readable
@@ -74,11 +82,32 @@ export class SmtpClient {
         this.assert_code(await this.read_command(), CommandCode.READY);
 
         await this.write_command(`EHLO ${config.hostname}\r\n`);
+
+        let supports_starttls = false;
+
         while (true) {
             const command = await this.read_command();
             if (!command || !command.args.startsWith("-")) break;
+            if (command.args.includes("STARTTLS")) {
+                supports_starttls = true;
+            }
         }
+
         if (this.use_authentication(config)) {
+            if (!this.isTlsConn(this.connection)) {
+                if (!supports_starttls) {
+                    throw new Error("STARTTLS is not supported by the server");
+                }
+                await this.write_command(`STARTTLS\r\n`);
+                this.assert_code(await this.read_command(), CommandCode.READY);
+                this.reader.cancel();
+                this.connection = await Deno.startTls(this.connection as Deno.TcpConn, { hostname: config.hostname });
+                this.reader = this.connection.readable
+                    .pipeThrough(new TextDecoderStream())
+                    .pipeThrough(new TextLineStream())
+                    .getReader();
+            }
+
             await this.write_command(`AUTH LOGIN\r\n`);
             this.assert_code(await this.read_command(), CommandCode.SERVER_CHALLENGE);
 
@@ -88,6 +117,10 @@ export class SmtpClient {
             await this.write_command(`${btoa(config.password)}\r\n`);
             this.assert_code(await this.read_command(), CommandCode.AUTHO_SUCCESS);
         }
+    }
+
+    isTlsConn(arg: Deno.Conn): arg is Deno.TlsConn {
+        return (arg as Deno.TlsConn).handshake !== undefined;
     }
 
     close() {


### PR DESCRIPTION
This PR adds support for STARTTLS.

The code was influenced by [denomailer](https://deno.land/x/denomailer).

**How it is used**
The user must NOT provide `SMTP_USETLS` in Environment Variables but MUST provide `SMTP_USERNAME` (and password of course).

@dangrie158 In case the code is not of your liking, feel free to change it. I merely wanted to provide the concept of how it can be supported.
P.S.: I haven't added any documentation about this feature. If you have any questions feel free to ask me.