### PR TITLE
Switch to alpine distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,37 @@
-FROM denoland/deno:1.46.3
+FROM denoland/deno:alpine-1.46.3
 
-ENV DOLCE_CUSTOM_TEMPLATE_PATH /var/dolce-custom-templates/
+ENV DOLCE_CUSTOM_TEMPLATE_PATH=/var/dolce-custom-templates/
+
+RUN apk update \
+    && apk add --no-cache curl \
+    && rm -f /var/cache/apk/*
 
 WORKDIR /dolce
 
 COPY . .
 
 RUN mkdir -p /var/run/dolce
+
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
 RUN deno cache main.ts lib/*.ts
 
 ENTRYPOINT []
+SHELL ["/bin/sh", "-c"]
 CMD deno run \
-# flag is needed for Deno.connect to a Unix Socket (lib/universal-http.ts)
+    # flag is needed for Deno.connect to a Unix Socket (lib/universal-http.ts)
     --unstable-http \
-# flag is needed for unstable KV storage
+    # flag is needed for unstable KV storage
     --unstable-kv \
-# flag is needed for unstable Cron
+    # flag is needed for unstable Cron
     --unstable-cron \
-# flag is needed for unstable Temporal API used in lib/chrono.ts and for blackout windows
+    # flag is needed for unstable Temporal API used in lib/chrono.ts and for blackout windows
     --unstable-temporal \
     --allow-read="./templates,${DOLCE_RUN_DIRECTORY:-/var/run/dolce/},${DOCKER_HOST:-/var/run/docker.sock},${DOLCE_CUSTOM_TEMPLATE_PATH}" \
     --allow-write="${DOLCE_RUN_DIRECTORY:-/var/run/dolce/},${DOCKER_HOST:-/var/run/docker.sock}" \
-# for SmtpNotifier
+    # for SmtpNotifier
     --allow-net="discord.com,api.telegram.org,${SMTP_HOSTNAME:-localhost},${APPRISE_HOST:-localhost}$( [ x${DOCKER_TRANSPORT:-unix} != 'xunix' ] && echo ,$DOCKER_HOST )" \
-# for lib/env.ts, obviously
+    # for lib/env.ts, obviously
     --allow-env \
-# for Deno.kill in lib/lockfile.ts
+    # for Deno.kill in lib/lockfile.ts
     --allow-run \
     main.ts


### PR DESCRIPTION
Resolves issues #27

This PR switches the produced docker image to the Alpine distro.

Notes:
- `curl` has been added to support `healthcheck` in `Docker Compose` i.e:
```
healthcheck:
    test: curl -s --unix-socket /var/run/docker.sock http/_ping || exit 1
    interval: 30s
    timeout: 10s
    retries: 5
    start_period: 10s
```

- `SHELL ["/bin/sh", "-c"]` has been added to get rid of `JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 20)` docker build warning.

P.S: File formatting has been done by the [VSCode Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)