### PR TITLE
docker-api: update to v1.45

### DIFF
--- a/lib/docker-api.ts
+++ b/lib/docker-api.ts
@@ -131,7 +131,7 @@ export type DockerApiEventFilters = {
 export class DockerApi {
     // we use the oldest version of the API that supports all the features we want
     // to be compatible with most versions.
-    public static DEFAULT_VERSION = "v1.27";
+    public static DEFAULT_VERSION = "v1.45";
     public static DEFAULT_SOCKET_PATH = new URL("unix:///var/run/docker.sock");
     public static DEFAULT_HEADERS = {
         Accept: "application/json",


### PR DESCRIPTION
Min docker API version in order to work with latest Docker v29

Solves https://github.com/dangrie158/dolce/issues/31