### PR TITLE
Fix STARTTLS according to RFC 3207

### DIFF
--- a/lib/smtp.ts
+++ b/lib/smtp.ts
@@ -87,11 +87,19 @@ export class SmtpClient {
     }
 
     private async connect(connection: Deno.Conn, config: ConnectConfig) {
+        if (connection === null) {
+            throw new Error("connection not established");
+        }
+
         this.connection = connection;
         this.reader = this.connection.readable
             .pipeThrough(new TextDecoderStream())
             .pipeThrough(new TextLineStream())
             .getReader();
+
+        if (this.reader === null) {
+            throw new Error("failed to establish reader");
+        }
 
         this.assert_code(await this.read_command(), CommandCode.READY);
 
@@ -117,10 +125,18 @@ export class SmtpClient {
                 this.assert_code(await this.read_command(), CommandCode.READY);
                 this.reader.cancel();
                 this.connection = await Deno.startTls(this.connection as Deno.TcpConn, { hostname: config.hostname });
+                if (connection === null) {
+                    throw new Error("connection not established");
+                }
+
                 this.reader = this.connection.readable
                     .pipeThrough(new TextDecoderStream())
                     .pipeThrough(new TextLineStream())
                     .getReader();
+                        
+                if (this.reader === null) {
+                    throw new Error("failed to establish reader");
+                }
 
                 await this.write_command(`EHLO ${config.hostname}\r\n`);
                 


### PR DESCRIPTION
Fixes issue #33

This PR does the following:
- Makes the STARTTLS connection comply to RFC 3207
- Adds guards for `connection` and `reader`

PR has been tested against:
- smtp.gmail.com
- private email provider that was giving the original error

Note: `smtp.gmail.com` was not producing any errors with the current implementation as Google seems to have more relaxed rules.